### PR TITLE
feat: add prettify option to release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ OPTIONS
   --ci                 CI mode (fully automatic release)
   --local              Release package to local registry
   --localUrl=localUrl  [default: http://localhost:4873/] URL to local registry
+  --prettify           Use prettier to format modified files when using --fix
 ```
 
 _See code: [src/commands/release.ts](https://github.com/nxpm/nxpm-cli/blob/v1.18.0/src/commands/release.ts)_

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.1",
     "@types/node-fetch": "^2.5.7",
+    "@types/prettier": "^2.2.3",
     "@types/tmp": "^0.2.0",
     "chai": "^4.2.0",
     "eslint": "^5.13",
@@ -46,8 +47,12 @@
     "lint-staged": "^10.2.2",
     "mocha": "^7.1.2",
     "nyc": "^15.0.1",
+    "prettier": "^2.2.1",
     "ts-node": "^8.10.1",
     "typescript": "3.8.3"
+  },
+  "optionalDependencies": {
+    "prettier": "^2.0.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -34,6 +34,10 @@ export default class Release extends BaseCommand {
       description: 'URL to local registry',
       default: 'http://localhost:4873/',
     }),
+    prettify: flags.boolean({
+      description: 'Use prettier to format modified files when using --fix',
+      default: false,
+    }),
   }
 
   static args = [
@@ -80,6 +84,7 @@ export default class Release extends BaseCommand {
       version: args.version,
       local: flags.local,
       localUrl: flags.localUrl,
+      prettify: flags.prettify,
     })
   }
 }

--- a/src/lib/release/interfaces/release-config.ts
+++ b/src/lib/release/interfaces/release-config.ts
@@ -10,4 +10,5 @@ export interface ReleaseConfig extends BaseConfig {
   local?: boolean
   localUrl?: string
   version: string
+  prettify?: boolean
 }

--- a/src/lib/release/release-validate.ts
+++ b/src/lib/release/release-validate.ts
@@ -106,6 +106,7 @@ export function validatePackages(
       version: config.version,
       name,
       workspacePkgJson: config.package,
+      prettify: config.prettify,
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,6 +662,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/prettier@^2.2.3":
+  version "2.2.3"
+  resolved "http://localhost:4873/@types%2fprettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
+  integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
+
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
@@ -4308,6 +4313,11 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier@^2.0.0:
+  version "2.2.1"
+  resolved "http://localhost:4873/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Adds a `--prettify` option to the release command. When the flag is used, updated package.json files are formatted with Prettier to match the nx workspace's Prettier/`.editorconfig` config.  This super helpful so that the release command is used, additional file modifications aren't made.

Not sure if making Prettier an optional dependency is the right call. I can see the argument that could be confusing, but could also see it being nice to not make those using `nxpm-cli` install Prettier if their repo doesn't use it.

Love the tool! The release command is gonna save us so much time.